### PR TITLE
Fix broken links in project sneak peek table

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
                         <td class="py-4 px-6">To-Do List App</td>
                         <td class="py-4 px-6 hidden sm:table-cell">DOM &amp; LocalStorage</td>
                         <td class="py-4 px-6">
-                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/main/01-To-Do%20List%20App"
+                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/master/01-To-Do%20List%20App"
                                 target="_blank"
                                 class="text-indigo-600 hover:text-indigo-500 flex items-center gap-1">GitHub<i
                                     data-lucide="external-link" class="w-4 h-4"></i></a>
@@ -213,7 +213,7 @@
                         <td class="py-4 px-6">Simple Calculator</td>
                         <td class="py-4 px-6 hidden sm:table-cell">DOM Math</td>
                         <td class="py-4 px-6">
-                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/main/02-Simple%20Calculator"
+                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/master/02-Simple%20Calculator"
                                 target="_blank"
                                 class="text-indigo-600 hover:text-indigo-500 flex items-center gap-1">GitHub<i
                                     data-lucide="external-link" class="w-4 h-4"></i></a>
@@ -224,7 +224,7 @@
                         <td class="py-4 px-6">Digital Clock</td>
                         <td class="py-4 px-6 hidden sm:table-cell">Date &amp; Time</td>
                         <td class="py-4 px-6">
-                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/main/03-Digital%20Clock"
+                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/master/03-Digital%20Clock"
                                 target="_blank"
                                 class="text-indigo-600 hover:text-indigo-500 flex items-center gap-1">GitHub<i
                                     data-lucide="external-link" class="w-4 h-4"></i></a>
@@ -235,7 +235,7 @@
                         <td class="py-4 px-6">Tip Calculator</td>
                         <td class="py-4 px-6 hidden sm:table-cell">Math Forms</td>
                         <td class="py-4 px-6">
-                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/main/04-Tip%20Calculator"
+                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/master/04-Tip%20Calculator"
                                 target="_blank"
                                 class="text-indigo-600 hover:text-indigo-500 flex items-center gap-1">GitHub<i
                                     data-lucide="external-link" class="w-4 h-4"></i></a>
@@ -246,7 +246,7 @@
                         <td class="py-4 px-6">Temperature Converter</td>
                         <td class="py-4 px-6 hidden sm:table-cell">Math Forms</td>
                         <td class="py-4 px-6">
-                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/main/05-Temperature%20Converter"
+                            <a href="https://github.com/pradipchaudhary/100-js-projects/tree/master/05-Temperature%20Converter"
                                 target="_blank"
                                 class="text-indigo-600 hover:text-indigo-500 flex items-center gap-1">GitHub<i
                                     data-lucide="external-link" class="w-4 h-4"></i></a>


### PR DESCRIPTION
Updated links in the project sneak peek table.
The links contained "main" and were leading to 404 pages.
Replaced "main" with "master" so the links now work.